### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #Multistream-select router
 This package implements a simple stream router for the multistream-select protocol.
-The protocol is defined [here](https://github.com/jbenet/multistream).
+The protocol is defined [here](https://github.com/multiformats/multistream-select).
 
 
 Usage:


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/jbenet/multistream | https://github.com/multiformats/multistream-select 
