### PR TITLE
Fix race condition for whandshake

### DIFF
--- a/lazy.go
+++ b/lazy.go
@@ -119,6 +119,9 @@ func (l *lazyConn) writeHandshake() error {
 }
 
 func (l *lazyConn) Write(b []byte) (int, error) {
+	l.whlock.Lock()
+	defer l.whlock.Unlock()
+	
 	if !l.whandshake {
 		go l.readHandshake()
 		err := l.writeHandshake()


### PR DESCRIPTION
See race condition reported at https://github.com/ipfs/go-ipfs/issues/4105

Reuse `whlock` for `whandshake`