### PR TITLE
fix benign race and clean up handshake logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ cache:
 notifications:
   email: false
 
-#env: GOTFLAGS="-race"
+env: GOTFLAGS="-race"

--- a/lazyServer.go
+++ b/lazyServer.go
@@ -5,6 +5,11 @@ import (
 	"sync"
 )
 
+// lazyServerConn is an io.ReadWriteCloser adapter used for negotiating inbound
+// streams (see NegotiateLazy).
+//
+// This is "lazy" because it doesn't wait for the write half to succeed before
+// allowing us to read from the stream.
 type lazyServerConn struct {
 	waitForHandshake sync.Once
 	werr             error
@@ -21,7 +26,6 @@ func (l *lazyServerConn) Write(b []byte) (int, error) {
 }
 
 func (l *lazyServerConn) Read(b []byte) (int, error) {
-	// TODO: The tests require this for some reason. Not sure if it's correct...
 	if len(b) == 0 {
 		return 0, nil
 	}

--- a/lazyServer.go
+++ b/lazyServer.go
@@ -1,0 +1,33 @@
+package multistream
+
+import (
+	"io"
+	"sync"
+)
+
+type lazyServerConn struct {
+	waitForHandshake sync.Once
+	werr             error
+
+	con io.ReadWriteCloser
+}
+
+func (l *lazyServerConn) Write(b []byte) (int, error) {
+	l.waitForHandshake.Do(func() { panic("didn't initiate handshake") })
+	if l.werr != nil {
+		return 0, l.werr
+	}
+	return l.con.Write(b)
+}
+
+func (l *lazyServerConn) Read(b []byte) (int, error) {
+	// TODO: The tests require this for some reason. Not sure if it's correct...
+	if len(b) == 0 {
+		return 0, nil
+	}
+	return l.con.Read(b)
+}
+
+func (l *lazyServerConn) Close() error {
+	return l.con.Close()
+}

--- a/multistream.go
+++ b/multistream.go
@@ -186,20 +186,15 @@ func (msm *MultistreamMuxer) NegotiateLazy(rwc io.ReadWriteCloser) (Multistream,
 	writeErr := make(chan error, 1)
 	defer close(pval)
 
-	lzc := &lazyConn{
-		con:        rwc,
-		rhandshake: true,
-		rhsync:     true,
+	lzc := &lazyServerConn{
+		con: rwc,
 	}
 
-	// take lock here to prevent a race condition where the reads below from
-	// finishing and taking the write lock before this goroutine can
-	lzc.whlock.Lock()
+	started := make(chan struct{})
+	go lzc.waitForHandshake.Do(func() {
+		close(started)
 
-	go func() {
 		defer close(writeErr)
-		defer lzc.whlock.Unlock()
-		lzc.whsync = true
 
 		if err := delimWriteBuffered(rwc, []byte(ProtocolID)); err != nil {
 			lzc.werr = err
@@ -214,8 +209,8 @@ func (msm *MultistreamMuxer) NegotiateLazy(rwc io.ReadWriteCloser) (Multistream,
 				return
 			}
 		}
-		lzc.whandshake = true
-	}()
+	})
+	<-started
 
 	line, err := ReadNextToken(rwc)
 	if err != nil {
@@ -232,6 +227,7 @@ loop:
 		// Now read and respond to commands until they send a valid protocol id
 		tok, err := ReadNextToken(rwc)
 		if err != nil {
+			rwc.Close()
 			return nil, "", nil, err
 		}
 
@@ -240,6 +236,7 @@ loop:
 			select {
 			case pval <- "ls":
 			case err := <-writeErr:
+				rwc.Close()
 				return nil, "", nil, err
 			}
 		default:
@@ -248,6 +245,7 @@ loop:
 				select {
 				case pval <- "na":
 				case err := <-writeErr:
+					rwc.Close()
 					return nil, "", nil, err
 				}
 				continue loop

--- a/multistream_test.go
+++ b/multistream_test.go
@@ -172,6 +172,7 @@ func TestNegLazyStressWrite(t *testing.T) {
 				t.Error(err)
 				return
 			}
+
 		}
 	}()
 


### PR DESCRIPTION
* Split lazy server and lazy client types. They're very different and do very different things.
* Combine lazy client write with handshake. This allows us to negotiate and write all in one go.

I'm *not* happy with the server-side logic but couldn't find a nice, clean way to fix it so I left it as it was (mostly). Eventually, we'll have to switch to a new protocol anyways because this one isn't sound.