### PR TITLE
first write, then read during the handshake

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,6 +44,10 @@ func SelectOneOf(protos []string, rwc io.ReadWriteCloser) (string, error) {
 }
 
 func handshake(rwc io.ReadWriteCloser) error {
+	if err := delimWrite(rwc, []byte(ProtocolID)); err != nil {
+		return err
+	}
+
 	tok, err := ReadNextToken(rwc)
 	if err != nil {
 		return err
@@ -52,12 +56,6 @@ func handshake(rwc io.ReadWriteCloser) error {
 	if tok != ProtocolID {
 		return errors.New("received mismatch in protocol id")
 	}
-
-	err = delimWrite(rwc, []byte(ProtocolID))
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/multistream_test.go
+++ b/multistream_test.go
@@ -231,9 +231,9 @@ func TestInvalidProtocol(t *testing.T) {
 	}()
 
 	ms := NewMultistream(b, "/THIS_IS_WRONG")
-	_, err := ms.Write(nil)
+	_, err := ms.Read([]byte{0})
 	if err == nil {
-		t.Fatal("this write should not succeed")
+		t.Fatal("this read should not succeed")
 	}
 
 	select {


### PR DESCRIPTION
Needed for QUIC support.

We have to use a TCP connection instead of `net.Pipe()` in the multistream tests, since the connections returned by `net.Pipe()` are not buffered, so it won't work if both sides write before reading.