### PR TITLE
write asynchronously when handshaking

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ func SelectOneOf(protos []string, rwc io.ReadWriteCloser) (string, error) {
 }
 
 func handshake(rwc io.ReadWriteCloser) error {
-	if err := delimWrite(rwc, []byte(ProtocolID)); err != nil {
+	if err := delimWriteBuffered(rwc, []byte(ProtocolID)); err != nil {
 		return err
 	}
 
@@ -60,7 +60,7 @@ func handshake(rwc io.ReadWriteCloser) error {
 }
 
 func trySelect(proto string, rwc io.ReadWriteCloser) error {
-	err := delimWrite(rwc, []byte(proto))
+	err := delimWriteBuffered(rwc, []byte(proto))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Given that *both* sides now try to write the multistream handshake out before reading, we need to do it asynchronously. Otherwise, we can deadlock (depending on the protocol).

In practice, this shouldn't be an issue but I'm not sure if we can really *guarantee* that.

This fix *does* cost us an ephemeral goroutine but I'm not sure if we can get away from that.