### PR TITLE
send fewer packets by combining writes when possible

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,6 +48,12 @@ func SelectOneOf(protos []string, rwc io.ReadWriteCloser) (string, error) {
 	if len(protos) == 0 {
 		return "", ErrNoProtocols
 	}
+
+	// Use SelectProtoOrFail to pipeline the /multistream/1.0.0 handshake
+	// with an attempt to negotiate the first protocol. If that fails, we
+	// can continue negotiating the rest of the protocols normally.
+	//
+	// This saves us a round trip.
 	switch err := SelectProtoOrFail(protos[0], rwc); err {
 	case nil:
 		return protos[0], nil

--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ var ErrNotSupported = errors.New("protocol not supported")
 
 // ErrNoProtocols is the error returned when the no protocols have been
 // specified.
-var ErrNoProtocols = errors.New("protocol not supported")
+var ErrNoProtocols = errors.New("no protocols specified")
 
 // SelectProtoOrFail performs the initial multistream handshake
 // to inform the muxer of the protocol that will be used to communicate

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package multistream
 
 import (
+	"bytes"
 	"errors"
 	"io"
 )
@@ -9,28 +10,52 @@ import (
 // the protocol specified for the handshake.
 var ErrNotSupported = errors.New("protocol not supported")
 
+// ErrNoProtocols is the error returned when the no protocols have been
+// specified.
+var ErrNoProtocols = errors.New("protocol not supported")
+
 // SelectProtoOrFail performs the initial multistream handshake
 // to inform the muxer of the protocol that will be used to communicate
 // on this ReadWriteCloser. It returns an error if, for example,
 // the muxer does not know how to handle this protocol.
 func SelectProtoOrFail(proto string, rwc io.ReadWriteCloser) error {
-	err := handshake(rwc)
-	if err != nil {
-		return err
+	errCh := make(chan error, 1)
+	go func() {
+		var buf bytes.Buffer
+		delimWrite(&buf, []byte(ProtocolID))
+		delimWrite(&buf, []byte(proto))
+		_, err := io.Copy(rwc, &buf)
+		errCh <- err
+	}()
+	// We have to read *both* errors.
+	err1 := readMultistreamHeader(rwc)
+	err2 := readProto(proto, rwc)
+	if werr := <-errCh; werr != nil {
+		return werr
 	}
-
-	return trySelect(proto, rwc)
+	if err1 != nil {
+		return err1
+	}
+	if err2 != nil {
+		return err2
+	}
+	return nil
 }
 
 // SelectOneOf will perform handshakes with the protocols on the given slice
 // until it finds one which is supported by the muxer.
 func SelectOneOf(protos []string, rwc io.ReadWriteCloser) (string, error) {
-	err := handshake(rwc)
-	if err != nil {
+	if len(protos) == 0 {
+		return "", ErrNoProtocols
+	}
+	switch err := SelectProtoOrFail(protos[0], rwc); err {
+	case nil:
+		return protos[0], nil
+	case ErrNotSupported: // try others
+	default:
 		return "", err
 	}
-
-	for _, p := range protos {
+	for _, p := range protos[1:] {
 		err := trySelect(p, rwc)
 		switch err {
 		case nil:
@@ -49,14 +74,16 @@ func handshake(rwc io.ReadWriteCloser) error {
 		errCh <- delimWriteBuffered(rwc, []byte(ProtocolID))
 	}()
 
-	tok, readErr := ReadNextToken(rwc)
-	writeErr := <-errCh
-
-	if writeErr != nil {
-		return writeErr
+	if err := readMultistreamHeader(rwc); err != nil {
+		return err
 	}
-	if readErr != nil {
-		return readErr
+	return <-errCh
+}
+
+func readMultistreamHeader(r io.ReadWriter) error {
+	tok, err := ReadNextToken(r)
+	if err != nil {
+		return err
 	}
 
 	if tok != ProtocolID {
@@ -70,8 +97,11 @@ func trySelect(proto string, rwc io.ReadWriteCloser) error {
 	if err != nil {
 		return err
 	}
+	return readProto(proto, rwc)
+}
 
-	tok, err := ReadNextToken(rwc)
+func readProto(proto string, rw io.ReadWriter) error {
+	tok, err := ReadNextToken(rw)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This makes the non-lazy negotiator act *slightly* more like the lazy one.
Instead of sending the multistream header and *then* the protocol header, it
sends them both in the same packet.

This *shouldn't* cause any issues but we should still think carefully about
whether or not this is worth it. It:

1. Sends fewer packets.
2. Saves half an RTT.