### PR TITLE
interface adjustments for abstraction friendliness

### DIFF
--- a/multistream.go
+++ b/multistream.go
@@ -21,7 +21,7 @@ const ProtocolID = "/multistream/1.0.0"
 
 // HandlerFunc is a user-provided function used by the MultistreamMuxer to
 // handle a protocol/stream.
-type HandlerFunc func(protocol string, rwc io.ReadWriteCloser) error
+type HandlerFunc = func(protocol string, rwc io.ReadWriteCloser) error
 
 // Handler is a wrapper to HandlerFunc which attaches a name (protocol) and a
 // match function which can optionally be used to select a handler by other
@@ -181,7 +181,7 @@ func (msm *MultistreamMuxer) findHandler(proto string) *Handler {
 // a multistream, the protocol used, the handler and an error. It is lazy
 // because the write-handshake is performed on a subroutine, allowing this
 // to return before that handshake is completed.
-func (msm *MultistreamMuxer) NegotiateLazy(rwc io.ReadWriteCloser) (Multistream, string, HandlerFunc, error) {
+func (msm *MultistreamMuxer) NegotiateLazy(rwc io.ReadWriteCloser) (io.ReadWriteCloser, string, HandlerFunc, error) {
 	pval := make(chan string, 1)
 	writeErr := make(chan error, 1)
 	defer close(pval)


### PR DESCRIPTION
This PR is part of a batch across go-libp2p repos to consolidate abstractions, interfaces and core types into [libp2p/go-libp2p-core](https://github.com/libp2p/go-libp2p-core). See branch [`consolidate-skeleton`](https://github.com/libp2p/go-libp2p-core/tree/consolidate-skeleton) there.

Work is being performed in the `consolidate-skeleton` branch across repos.

In this PR, we make backwards-compatible adjustments for go-multistream to conform to the new [`protocol.Negotiator` interface](https://github.com/libp2p/go-libp2p-core/blob/master/protocol/switch.go#L53).

---

Merge strategy: squash and rebase.