### PR TITLE
ls: make ls more consistent with other protocols

### DIFF
--- a/client.go
+++ b/client.go
@@ -74,13 +74,13 @@ func SelectOneOf(protos []string, rwc io.ReadWriteCloser) (string, error) {
 	return "", ErrNotSupported
 }
 
-func handshake(rwc io.ReadWriteCloser) error {
+func handshake(rw io.ReadWriter) error {
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- delimWriteBuffered(rwc, []byte(ProtocolID))
+		errCh <- delimWriteBuffered(rw, []byte(ProtocolID))
 	}()
 
-	if err := readMultistreamHeader(rwc); err != nil {
+	if err := readMultistreamHeader(rw); err != nil {
 		return err
 	}
 	return <-errCh


### PR DESCRIPTION
fixes #41

Note: To make the `Ls` helper actually _useful_, it now performs the handshake
internally. Really, this library isn't built for interactive use while `ls` _is_
so the interfaces are going to be kind of wonky.