### PR TITLE
handle timeouts using i/o deadlines.

### DIFF
--- a/multistream.go
+++ b/multistream.go
@@ -205,6 +205,12 @@ func (msm *MultistreamMuxer) NegotiateLazy(rwc io.ReadWriteCloser) (io.ReadWrite
 	writeErr := make(chan error, 1)
 	defer close(pval)
 
+	if clearFn, err := setDeadline(rwc); err != nil {
+		return nil, "", nil, err
+	} else {
+		defer clearFn()
+	}
+
 	lzc := &lazyServerConn{
 		con: rwc,
 	}
@@ -292,6 +298,12 @@ loop:
 // Negotiate performs protocol selection and returns the protocol name and
 // the matching handler function for it (or an error).
 func (msm *MultistreamMuxer) Negotiate(rwc io.ReadWriteCloser) (string, HandlerFunc, error) {
+	if clearFn, err := setDeadline(rwc); err != nil {
+		return "", nil, err
+	} else {
+		defer clearFn()
+	}
+
 	// Send our protocol ID
 	err := delimWriteBuffered(rwc, []byte(ProtocolID))
 	if err != nil {

--- a/timeout.go
+++ b/timeout.go
@@ -1,0 +1,32 @@
+package multistream
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// NegotiationTimeout is the maximum time a protocol negotiation atempt is
+// allowed to be inflight before it fails.
+var NegotiationTimeout = 30 * time.Second
+
+// setDeadline attempts to set a read and write deadline on the underlying IO
+// object, if it supports it.
+func setDeadline(rwc io.ReadWriteCloser) (func(), error) {
+	// rwc could be:
+	// - a net.Conn or a libp2p Stream, both of which satisfy this interface.
+	// - something else (e.g. testing), in which case we skip over setting
+	//   a deadline.
+	type deadline interface {
+		SetDeadline(time.Time) error
+	}
+	if d, ok := rwc.(deadline); ok {
+		if err := d.SetDeadline(time.Now().Add(NegotiationTimeout)); err != nil {
+			// this should not happen; if it does, something is broken and we
+			// should fail immediately.
+			return nil, fmt.Errorf("failed while setting a deadline: %w", err)
+		}
+		return func() { d.SetDeadline(time.Time{}) }, nil
+	}
+	return func() {}, nil
+}


### PR DESCRIPTION
Both initiator and responder now time out if reads and/or writes are blocked for 30 seconds (default negotiation timeout).

Introduces two tests to validate the new behaviour.

Fixes #47.