### PR TITLE
change the simultaneous open protocol to /libp2p/simultaneous-connect

### DIFF
--- a/client.go
+++ b/client.go
@@ -76,6 +76,8 @@ func SelectOneOf(protos []string, rwc io.ReadWriteCloser) (string, error) {
 	return selectProtosOrFail(protos[1:], rwc)
 }
 
+const simOpenProtocol = "/libp2p/simultaneous-connect"
+
 // Performs protocol negotiation with the simultaneous open extension; the returned boolean
 // indicator will be true if we should act as a server.
 func SelectWithSimopenOrFail(protos []string, rwc io.ReadWriteCloser) (string, bool, error) {
@@ -86,7 +88,7 @@ func SelectWithSimopenOrFail(protos []string, rwc io.ReadWriteCloser) (string, b
 	werrCh := make(chan error, 1)
 	go func() {
 		var buf bytes.Buffer
-		if err := delitmWriteAll(&buf, []byte(ProtocolID), []byte("iamclient"), []byte(protos[0])); err != nil {
+		if err := delitmWriteAll(&buf, []byte(ProtocolID), []byte(simOpenProtocol), []byte(protos[0])); err != nil {
 			werrCh <- err
 			return
 		}
@@ -110,19 +112,16 @@ func SelectWithSimopenOrFail(protos []string, rwc io.ReadWriteCloser) (string, b
 	}
 
 	switch tok {
-	case "iamclient":
+	case simOpenProtocol:
 		// simultaneous open
 		return simOpen(protos, rwc)
-
 	case "na":
 		// client open
 		proto, err := clientOpen(protos, rwc)
 		if err != nil {
 			return "", false, err
 		}
-
 		return proto, false, nil
-
 	default:
 		return "", false, errors.New("unexpected response: " + tok)
 	}


### PR DESCRIPTION
See https://github.com/libp2p/specs/pull/321.

This is ok since the last libp2p release (v0.13.0) included go-multistream v0.2.0, which didn't have simultaneous open support yet.

cc @mxinden (can't add you as a reviewer here)