### PR TITLE
remove unused ls command

### DIFF
--- a/client.go
+++ b/client.go
@@ -284,18 +284,6 @@ func simOpenSelectClient(protos []string, rwc io.ReadWriteCloser) (string, error
 	return selectProtosOrFail(protos, rwc)
 }
 
-func handshake(rw io.ReadWriter) error {
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- delimWriteBuffered(rw, []byte(ProtocolID))
-	}()
-
-	if err := readMultistreamHeader(rw); err != nil {
-		return err
-	}
-	return <-errCh
-}
-
 func readMultistreamHeader(r io.Reader) error {
 	tok, err := ReadNextToken(r)
 	if err != nil {


### PR DESCRIPTION
As far as I can tell, `ls` is the main reason we're using a 64 kB buffer when reading tokens in https://github.com/multiformats/go-multistream/blob/711a0aaf37fdd541271c6c829083c59247219108/multistream.go#L440-L444.

Given that this protocols is used by neither libp2p, IPFS or lotus, and we're in the process of replacing multistream with Protocol Select anyway, it seems safe to remove, especially given that this doesn't seem to be part of the [spec](https://github.com/libp2p/specs/blob/master/connections/README.md).