### PR TITLE
reduce the maximum read buffer size from 64 to 1 kB

### DIFF
--- a/multistream.go
+++ b/multistream.go
@@ -352,7 +352,7 @@ func lpReadBuf(r io.Reader) ([]byte, error) {
 		return nil, err
 	}
 
-	if length > 64*1024 {
+	if length > 1024 {
 		return nil, ErrTooLarge
 	}
 


### PR DESCRIPTION
Now that `ls` is removed, there's no need for super large messages any more.