### PR TITLE
Ignore error if can't write back echoed protocol in negotiate

### DIFF
--- a/multistream.go
+++ b/multistream.go
@@ -235,10 +235,10 @@ loop:
 			continue loop
 		}
 
-		_ = delimWriteBuffered(rwc, []byte(tok))
 		// Ignore the error here.  We want the handshake to finish, even if the
-		// other size has closed this rwc for writing. They may have sent us a
-		// message and closed. Future writers will get an error here anyways.
+		// other side has closed this rwc for writing. They may have sent us a
+		// message and closed. Future writers will get an error anyways.
+		_ = delimWriteBuffered(rwc, []byte(tok))
 
 		// hand off processing to the sub-protocol handler
 		return tok, h.Handle, nil

--- a/multistream.go
+++ b/multistream.go
@@ -235,9 +235,10 @@ loop:
 			continue loop
 		}
 
-		if err := delimWriteBuffered(rwc, []byte(tok)); err != nil {
-			return "", nil, err
-		}
+		_ = delimWriteBuffered(rwc, []byte(tok))
+		// Ignore the error here.  We want the handshake to finish, even if the
+		// other size has closed this rwc for writing. They may have sent us a
+		// message and closed. Future writers will get an error here anyways.
 
 		// hand off processing to the sub-protocol handler
 		return tok, h.Handle, nil


### PR DESCRIPTION
We would fail to negotiate if we couldn't echo back the protocol id. It should be valid to fail to write back the protocol ID and return the negotiate stream so that the caller may read data from the stream.

This pattern is common when a dialer opens a new stream, sends some data, then closes the stream immediately. (bitswap, graphsync). Without this there's really nothing a caller can do besides sleep enough to let the other side send it's multistream protocol response.

Fixes: 
- https://github.com/ipfs/go-ipfs/pull/9038#pullrequestreview-1003663418
- https://github.com/ipfs/go-graphsync/pull/388

This is a regression from https://github.com/multiformats/go-multistream/pull/85. NegotiateLazy would not fail to negotiate for the listener.

r? @marten-seemann cc @Stebalien 