### PR TITLE
Ignore error if can't write back multistream protocol id

### DIFF
--- a/multistream.go
+++ b/multistream.go
@@ -204,10 +204,11 @@ func (msm *MultistreamMuxer) Negotiate(rwc io.ReadWriteCloser) (proto string, ha
 		}
 	}()
 
-	// Send our protocol ID
-	if err := delimWriteBuffered(rwc, []byte(ProtocolID)); err != nil {
-		return "", nil, err
-	}
+	// Send the multistream protocol ID
+	// Ignore the error here.  We want the handshake to finish, even if the
+	// other side has closed this rwc for writing. They may have sent us a
+	// message and closed. Future writers will get an error anyways.
+	_ = delimWriteBuffered(rwc, []byte(ProtocolID))
 
 	line, err := ReadNextToken(rwc)
 	if err != nil {

--- a/multistream_test.go
+++ b/multistream_test.go
@@ -665,7 +665,7 @@ func (rob *readonlyBuffer) Close() error {
 	return nil
 }
 
-func TestNegotiateFail(t *testing.T) {
+func TestNegotiatThenWriteFail(t *testing.T) {
 	buf := new(bytes.Buffer)
 
 	err := delimWrite(buf, []byte(ProtocolID))
@@ -683,9 +683,15 @@ func TestNegotiateFail(t *testing.T) {
 
 	rob := &readonlyBuffer{bytes.NewReader(buf.Bytes())}
 	_, _, err = mux.Negotiate(rob)
-	if err == nil {
-		t.Fatal("Negotiate should fail here")
+	if err != nil {
+		t.Fatal("Negotiate should not fail here")
 	}
+
+	_, err = rob.Write([]byte("app data"))
+	if err == nil {
+		t.Fatal("Write should fail here")
+	}
+
 }
 
 type mockStream struct {


### PR DESCRIPTION
A continuation of https://github.com/multiformats/go-multistream/pull/87. It's the same thing, but we didn't account for the case the the stream is closed so early we don't get a chance to write our multistream select protocol id.

Worth noting that the old NegotiateLazy also ignored this error, so it should be a safe change (since this is the same as the old behavior).
