### PR TITLE
Fix errors Is checking

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,6 +25,11 @@ func (e ErrNotSupported[T]) Error() string {
 	return fmt.Sprintf("protocols not supported: %v", e.Protos)
 }
 
+func (e ErrNotSupported[T]) Is(target error) bool {
+	_, ok := target.(ErrNotSupported[T])
+	return ok
+}
+
 // ErrNoProtocols is the error returned when the no protocols have been
 // specified.
 var ErrNoProtocols = errors.New("no protocols specified")

--- a/multistream_test.go
+++ b/multistream_test.go
@@ -1015,4 +1015,14 @@ func TestComparableErrors(t *testing.T) {
 	if errors.Is(err1, ErrNotSupported[Bar]{}) {
 		t.Fatalf("Should not be comparable")
 	}
+
+	err3 := ErrNotSupported[string]{}
+
+	if !errors.As(err2, &err3) {
+		t.Fatalf("Should be comparable")
+	}
+
+	if err3.Protos[0] != "/a" {
+		t.Fatalf("Should be read as ErrNotSupported")
+	}
 }

--- a/multistream_test.go
+++ b/multistream_test.go
@@ -3,6 +3,7 @@ package multistream
 import (
 	"bytes"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -996,4 +997,22 @@ func FuzzMultistream(f *testing.F) {
 		mux.AddHandler("/b", nil)
 		_ = mux.Handle(input)
 	})
+}
+
+func TestComparableErrors(t *testing.T) {
+	var err1 error = ErrNotSupported[string]{[]string{"/a"}}
+	if !errors.Is(err1, ErrNotSupported[string]{}) {
+		t.Fatalf("Should be comparable")
+	}
+
+	err2 := fmt.Errorf("This is wrapped: %w", err1)
+	if !errors.Is(err2, ErrNotSupported[string]{}) {
+		t.Fatalf("Should be comparable")
+	}
+
+	type Bar string
+
+	if errors.Is(err1, ErrNotSupported[Bar]{}) {
+		t.Fatalf("Should not be comparable")
+	}
 }


### PR DESCRIPTION
Callers expect to be able to check if an error is a ErrNotSupported. The generics change things so we need to explicitly add a `.Is` method.