### PR TITLE
Fix typo in unexported function name

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,7 +55,7 @@ func SelectProtoOrFail[T StringLike](proto T, rwc io.ReadWriteCloser) (err error
 	errCh := make(chan error, 1)
 	go func() {
 		var buf bytes.Buffer
-		if err := delitmWriteAll(&buf, []byte(ProtocolID), []byte(proto)); err != nil {
+		if err := delimWriteAll(&buf, []byte(ProtocolID), []byte(proto)); err != nil {
 			errCh <- err
 			return
 		}
@@ -129,7 +129,7 @@ func SelectWithSimopenOrFail[T StringLike](protos []T, rwc io.ReadWriteCloser) (
 	werrCh := make(chan error, 1)
 	go func() {
 		var buf bytes.Buffer
-		if err := delitmWriteAll(&buf, []byte(ProtocolID), []byte(simOpenProtocol), []byte(protos[0])); err != nil {
+		if err := delimWriteAll(&buf, []byte(ProtocolID), []byte(simOpenProtocol), []byte(protos[0])); err != nil {
 			werrCh <- err
 			return
 		}

--- a/multistream.go
+++ b/multistream.go
@@ -88,10 +88,10 @@ func delimWriteBuffered(w io.Writer, mes []byte) error {
 	return bw.Flush()
 }
 
-func delitmWriteAll(w io.Writer, messages ...[]byte) error {
+func delimWriteAll(w io.Writer, messages ...[]byte) error {
 	for _, mes := range messages {
 		if err := delimWrite(w, mes); err != nil {
-			return fmt.Errorf("failed to write messages %s, err: %v	", string(mes), err)
+			return fmt.Errorf("failed to write messages %s, err: %w	", mes, err)
 		}
 	}
 


### PR DESCRIPTION
It looks like this was supposed to be "delim" write all -- "delitm" doesn't mean anything.

Also skip casting the bytes slice to a string before formatting as %s, as the cast is redundant; and prefer %w for wrapping an error, for potential later use of errors.Is or errors.As.