### PR TITLE
refactor(lazyClientConn): Use synctest friendly once func

### DIFF
--- a/multistream_test.go
+++ b/multistream_test.go
@@ -941,7 +941,7 @@ func TestComparableErrors(t *testing.T) {
 }
 
 func TestOnceFunc(t *testing.T) {
-	o := newOnceFunc()
+	o := newOnce()
 	start := make(chan struct{})
 	var runCount int
 	var wg sync.WaitGroup


### PR DESCRIPTION
Changes the sync.Once usage to a synctest friendly once version. More context on synctest here: https://go.dev/blog/synctest.

synctest doesn't consider code blocked by a mutex as "durably blocked." This makes sense for the common case where a mutex protects some critical section of code that runs quickly. In multistream's case the protected section of a mutex does IO (it finishes the handshake). This would mean that you would end up deadlocked in a synctest bubble because one goroutine would be waiting to acquire the lock, but the goroutine that would free the lock wouldn't be able to make progress because no network IO or time would happen.

With this change basichost works with synctest.